### PR TITLE
Troca do Linter de Dockerfile para o Hadolint - issue #7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,12 +27,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 #---------------------step 01-02-----------------------
-      - name: lint
-        uses: luke142367/Docker-Lint-Action@v1.1.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: hadolint/hadolint-action@v1.5.0
         with:
-          target: Dockerfile
+          dockerfile: Dockerfile
 
 #------------------------------------------------------
 #              job 02 - Teste do container

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ ARG TIKA_VERSION=1.27
 FROM apache/tika:$TIKA_VERSION
 
 RUN DEBIAN_FRONTEND=noninteractive \
-    apt-get update && apt-get -y --no-install-recommends install tesseract-ocr-por \
+    apt-get update && apt-get -y --no-install-recommends install tesseract-ocr-por=1:4.00~git30-7274cfa-1 \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Todos as etapas estão interligadas, conforme imagem acima, de forma que o está
 Esse job utiliza dois steps:
 
 - `step 01-01` - [Checkout](https://github.com/marketplace/actions/checkout)
-- `step 01-02` - [lint](https://github.com/marketplace/actions/docker-lint)
+- `step 01-02` - [lint](https://github.com/marketplace/actions/hadolint-action)
 
 ### job 02 - Teste do container
 


### PR DESCRIPTION
@gomex e @somatorio, fiz esse PR (resolve a issue #7 ) por sugestão do Caio na semana passada. Essa _Linter_ é bem mais conhecido e penso que podemos usá-lo como padrão em todos os nossos CI's. O que acham? 

URL's de referência:
- [repositório](https://github.com/hadolint/hadolint)
- [marketplace](https://github.com/marketplace/actions/hadolint-action)
- [hadolint online](https://hadolint.github.io/hadolint/)