### PR TITLE
Pull da imagem docker na criação de release. Complemento da issue #10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,16 @@
 #------------------------------------------------------
 # Nome da action e quando ela é disparada
 name: Fluxo para construcao e publicacao do container
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  release:
+    types:
+      - created
 
 #------------------------------------------------------
 #                      Variáveis


### PR DESCRIPTION
O PR #12 estava com um gap, visto que ao criar a release no GitHub o pull da imagem não ocorria. Com essa modificação o CI roda completo ao criar releases.