### PR TITLE
ci: Atualiza versão do tika

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ on:
 #                      Variáveis
 #------------------------------------------------------
 env:
-  tika_version: '2.3.0'
+  tika_version: '2.4.0'
 
 #------------------------------------------------------
 #                   Início dos jobs
@@ -30,7 +30,7 @@ jobs:
 #------------------------------------------------------
   lint:
     name: Lint do Dockerfile
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
 #---------------------step 01-01-----------------------
       - name: Checkout
@@ -46,7 +46,7 @@ jobs:
   test:
     name: Teste do container
     needs: lint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
 #---------------------step 02-01-----------------------
       - uses: actions/checkout@v2
@@ -78,7 +78,7 @@ jobs:
   scan:
     name: Scan da Imagem
     needs: lint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
 #---------------------step 03-01-----------------------
       - name: Checkout code
@@ -105,7 +105,7 @@ jobs:
     name: Publica a Imagem
     if: ${{ github.event_name == 'release' && github.event.action == 'created' }}
     needs: [scan, test]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
 #---------------------step 04-01-----------------------
       - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,20 @@
 ARG TIKA_VERSION
 
-FROM apache/tika:$TIKA_VERSION
+FROM midgardhero/tika:$TIKA_VERSION
+
+USER root
 
 RUN apt-get update \
     && apt-get -y --no-install-recommends install \
     openssl=1.1.1f-1ubuntu2.12 \
     libssl1.1=1.1.1f-1ubuntu2.12 \
-    libsystemd0=245.4-4ubuntu3.13 \
-    libudev1=245.4-4ubuntu3.13 \
+    libsystemd0=245.4-4ubuntu3.16 \
+    libudev1=245.4-4ubuntu3.16 \
     tesseract-ocr-por=1:4.00~git30-7274cfa-1 \
     libexpat1=2.2.9-1ubuntu0.4 \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# retorna o usuário para o padrão do TIKA
+# https://github.com/apache/tika-docker/blob/a4556b9e774f4c576b198836cedae0597ed59506/minimal/Dockerfile#L19
+USER 35002:35002

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 ARG TIKA_VERSION
 
-FROM midgardhero/tika:$TIKA_VERSION
-
-USER root
+FROM apache/tika:$TIKA_VERSION
 
 RUN apt-get update \
     && apt-get -y --no-install-recommends install \
@@ -14,7 +12,3 @@ RUN apt-get update \
     libexpat1=2.2.9-1ubuntu0.4 \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# retorna o usuário para o padrão do TIKA
-# https://github.com/apache/tika-docker/blob/a4556b9e774f4c576b198836cedae0597ed59506/minimal/Dockerfile#L19
-USER 35002:35002


### PR DESCRIPTION
A versão:2.3.0 possui algumas vulnerabilidades que foram corrigidas
com a atualização para versão:2.4.0. Como a imagem oficial do apache
ainda não foi publicada, efetuamos a criação de imagem própria não-oficial.

Com a versão nova, foi atualizada a versão do UBUNTU então tivemos que
atualizar alguns pacotes.

Ao atualizar a imagem, recebemos erros de permissão negada ao rodar comandos
apt, por isso alteramos o usuário para root e depois de rodar os comandos,
retornamos ao usuário do tika.

Co-authored-by: Luiz Aoqui <lgfa29@gmail.com>
Co-authored-by: Edemir Toldo <edemirtoldo@gmail.com>
Co-authored-by: Carlos Henrique <carlos_henrique190@yahoo.com.br>
Co-authored-by: Henrique Mizael <hmizael@gmail.com>
Co-authored-by: Murillo Gomes <mganalistati@gmail.com>
Co-authored-by: William San Martin <williamsanmartin4@gmail.com>
Co-authored-by: Marcos Medeiros  <soulinux@gmail.com>