### PR TITLE
CI: remove o arg TIKA_VERSION e a opção -build-arg

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Build - Stack
         run: |
           set -ex \
-          && docker-compose build --build-arg TIKA_VERSION=${{ env.tika_version }} \
+          docker-compose build \
           && docker-compose up -d tika
 #---------------------step 02-04-----------------------
       - name: Teste
@@ -86,7 +86,7 @@ jobs:
 #---------------------step 03-02-----------------------
       - name: Build an image from Dockerfile
         run: |
-          docker build --build-arg TIKA_VERSION=${{ env.tika_version }} -t tika-image .
+          docker build -t tika-image .
 #---------------------step 03-03-----------------------
       - name: Scanear Imagem com Trivy
         uses: aquasecurity/trivy-action@master
@@ -146,8 +146,6 @@ jobs:
           tags: ${{ secrets.DOCKERHUB_ORGANIZATION }}/tika-server:${{ github.event.release.tag_name }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-          build-args: |
-              TIKA_VERSION=${{ env.tika_version }}
 #---------------------step 04-07-----------------------
       - name: Digest
         run: echo "Versão usada para fazer push do Tika é -> ${{ env.tika_version }}"

--- a/.github/workflows/scan-image-cron.yml
+++ b/.github/workflows/scan-image-cron.yml
@@ -31,7 +31,7 @@ jobs:
 #---------------------step 01-02-----------------------
       - name: Build an image from Dockerfile
         run: |
-          docker build --build-arg TIKA_VERSION=${{ env.tika_version }} -t tika-image .
+          docker build -t tika-image .
 #---------------------step 01-03-----------------------
       - name: Scanear Imagem com Trivy
         uses: aquasecurity/trivy-action@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-ARG TIKA_VERSION
-
-FROM apache/tika:$TIKA_VERSION
+FROM apache/tika:2.4.0
 
 RUN apt-get update \
     && apt-get -y --no-install-recommends install \


### PR DESCRIPTION
# Titulo
Substituímos a opção `ARG TIKA_VERSION` do Dockerfile para uma definição estática, conforme exemplo abaixo:
```
FROM apache/tika:2.4.0
```
Além disso, removemos o parâmetro `--build-arg`  do arquivos de configuração do ci-cd.


<!-- Por favor descreva seu pull request aqui. -->

- [x] Garanta que seu **topic/feature/bugfix branch** tenha uma branch nomeada e não a sua branch main esteja no PR
- [ x] Dê um titulo que expresse o objetivo do PR
- [ x] Associe seu PR a uma Issue criada no repositósito. Caso seja uma correção de linguagem ou pequenas correções, não é necessário
- [ x] Descreva o objetivo do PR
- [ x] Inclua links relevantes para a sua modificação/sugestão/correção
- [x ] Descreva um passo-a-passo para testar o seu PR

## Issue
#26 
<!-- Link da issue -->

## Objetivo

- Remover a opção `ARG TIKA_VERSION` do Dockerfile.
- Remover o parâmetro `-build-arg` do arquivo de configuração do ci-cd.

<!-- Descrição do objetivo -->
